### PR TITLE
Added "YES RATE" and "NO RATE" to SIMD-0096 tally.sh.  These display

### DIFF
--- a/votes/simd0096/tally.sh
+++ b/votes/simd0096/tally.sh
@@ -34,6 +34,8 @@ TOTAL=$(echo "$YES + $NO + $ABSTAIN" | bc)
 SUPPLY=$(fetch_total_supply)
 YES_PCT=$(echo "scale=4; $YES / $SUPPLY * 100" | bc)
 NO_PCT=$(echo "scale=4; $NO / $SUPPLY * 100" | bc)
+YES_RATE=$(echo "scale=4; ($YES * 100) / ($YES + $NO)" | bc)
+NO_RATE=$(echo "scale=4; ($NO * 100) / ($YES + $NO)" | bc)
 ABSTAIN_PCT=$(echo "scale=4; $ABSTAIN / $SUPPLY * 100" | bc)
 TOTAL_PCT=$(echo "scale=4; $TOTAL / $SUPPLY * 100" | bc)
 
@@ -41,5 +43,8 @@ print_row "YES" "$YES_PCT" "$YES"
 print_row "NO" "$NO_PCT" "$NO"
 print_row "ABSTAIN" "$ABSTAIN_PCT" "$ABSTAIN"
 echo ""
-print_row "CASTED" "$TOTAL_PCT" "$TOTAL"
+print_row "YES RATE" "$YES_RATE" ""
+print_row "NO RATE" "$NO_RATE" ""
+echo ""
+print_row "CAST" "$TOTAL_PCT" "$TOTAL"
 print_row "SUPPLY" "100" "$SUPPLY"


### PR DESCRIPTION
the percentages of yes and no votes relative to the total number of yes and no votes, which are the most relevant numbers for determining if the vote is passing.